### PR TITLE
Update saturn-console.sql

### DIFF
--- a/saturn-docker/saturn-db/saturn-console.sql
+++ b/saturn-docker/saturn-db/saturn-console.sql
@@ -1,6 +1,10 @@
 
 SET FOREIGN_KEY_CHECKS=0;
 
+CREATE DATABASE saturn_console;
+
+USE saturn_console;
+
 -- ----------------------------
 -- Table structure for `job_config`
 -- ----------------------------


### PR DESCRIPTION
quickstart里面,console连接的数据库是saturn_console,但db镜像没有创建此数据库,添加到脚本里面