### PR TITLE
对saturn 3.3.1不支持分片失败立即转移的改造

### DIFF
--- a/saturn-console-api/pom.xml
+++ b/saturn-console-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.vip.saturn</groupId>
 		<artifactId>saturn-job</artifactId>
-		<version>master-SNAPSHOT</version>
+		<version>3.3.1</version>
 	</parent>
 	<artifactId>saturn-console-api</artifactId>
 	<packaging>jar</packaging>

--- a/saturn-console-web/pom.xml
+++ b/saturn-console-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vip.saturn</groupId>
         <artifactId>saturn-job</artifactId>
-        <version>master-SNAPSHOT</version>
+        <version>3.3.1</version>
     </parent>
     <artifactId>saturn-console-web</artifactId>
     <packaging>pom</packaging>

--- a/saturn-console/pom.xml
+++ b/saturn-console/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.vip.saturn</groupId>
 		<artifactId>saturn-job</artifactId>
-		<version>master-SNAPSHOT</version>
+		<version>3.3.1</version>
 	</parent>
 	<artifactId>saturn-console</artifactId>
 	<packaging>jar</packaging>

--- a/saturn-console/src/main/java/com/vip/saturn/job/console/springboot/DbPasswordCallback.java
+++ b/saturn-console/src/main/java/com/vip/saturn/job/console/springboot/DbPasswordCallback.java
@@ -1,0 +1,36 @@
+package com.vip.saturn.job.console.springboot;
+
+import com.alibaba.druid.util.DruidPasswordCallback;
+import com.vip.saturn.job.console.springboot.utils.RSAKeysUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+public class DbPasswordCallback extends DruidPasswordCallback {
+
+    private static final Logger log = LoggerFactory.getLogger(DbPasswordCallback.class);
+
+    /**
+     * 私钥对数据进行解密
+     */
+    private static final String PRIVATE_KEY_STRING = "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCCrE/StGyQ/+YVtMA4G3YK2xsFuST4msH18nCgH+OzNkmbmR+9MQ5Pfx2dJXtSEwdcyNPp5UTGejQU+3bIUensX3OsRwm7lnhrWp16VGBgsPyUJd2GVcT7Glte25FMh0SZvQgtO2f5YMSl1GLNYS1pSAonQnOaMB8TxYnV60MMJ7Lf9KDN9dXL0yJpXu+8/v/UoAD+A4qLUKNRA2bwc/SIwUVzLQ1ezoDvy/2GbUZoL9bbt8Zt3elMFPK5XjyPZoRpR4O1I2+40YXzkGX7UWkvilKMLWiH9gc8bb1Lo67qzVbsrK+xX53Fp5uFXWapzVd88uQE1j67OTmmIyNM4jvXAgMBAAECggEBAIBmasUjLq7IFMDtbBd1vGbsZ0AXbiGuh7pxcIOW8jottORk8RAJPQOWZ3X715KNSiW83KYu94aDm9umQFCUVORD4ri80O5363mpf6YtdMpt/rJgBq2yZ61Jd9DctYhaPmlGmts/TWp40KIV8MPYojOaaweqv0cZ09+sskT2OFqezmwITynTFr+oUI8zfwvuXi+dXkosiaH2Po1trP6q3/sO3RVIn1WuFvzIueIRSg4/xm1OU6UQ3tI7aX5sM7GfKTBia0pjQgaDExrp8FbY2RGzfGcZ0J91B66IyLRTPIXnoGYVCkqU8QKeQy2RWZsuUhC5JtIEKYVGHrRe0anQt+kCgYEA8P9G90KQZFrWoERFLtMLYSYimrNdm7Ght0R75q4dobruEH8yl3/IoVnvqe+qRwC/Gtc8Iz1MPvmweP276GyaXds+19E8J+e4VukW239A9CbsRRuVIG6WdAZsOanaE8gMpFX/kgRsgUzkbbKE6XWji3D4YcUjApH9cL/LEio0+rsCgYEAis7SfC5uknxCms1KAVk1NWICkeQWzDQIBfcqN8yaohScTYgwLDsUBd9VgxpeX5TQybRMHtNB/O7YVXyH308vyxN6yvdcTQ2gYviIrI/lggbgwh/qGWZTTHOeLGeVtWJlt33H6YZL5u37cVt86ZXYewFdEDIVrJoSLtNYAdX4l5UCgYB3DEOMJS+aw1y+crsSNGKsrN/vN6eIH6lZFNV30I8Gs4aiU5M0T4VWX00Kzz94L6A3rBci+UbO3R0Vx5GpcOyYbJOQnOVweQEQvbfy2dvGP+v6/3MdQEPGMN4JZiQ6HVpRW8IR6WmIPemhXsxVXy1Y1od8FJwEywU9SyEPahYdvQKBgFtNDM/Xrq01hI3UCCB47/GsBOq3L3Ojqb9awu8u6ms/yUuKD72YImR2cQWp+3c9KFPz/rmr1VSsOamJHsn4iQQ3TOZh69lW5C8VMLjocVqkcYPegBmy34mC5wBoJeXH0gXueucUiapc0K3QMopmIJ1P2UnE19LPCLS6GMIkXr49AoGBAJ7JhexixTTnOyqvZokIaMAC4Ce74jUynJTim0u8yeNchqECeCsfmmrryrkdUFigNt9o00YGF66B6ow20aIBSXxan6/VpZ72ham9l0r9I7xn/OfJNDROr6UFr1N/l1LzlBKI4cdYXa9v9BWj+0gxiLJ3rQ9qbyARXFEzo/Ick2qF";
+
+    @Override
+    public void setProperties(Properties properties) {
+        super.setProperties(properties);
+        String pwd = properties.getProperty("password");
+        log.info("get pw: " + pwd);
+        if (StringUtils.isNotBlank(pwd)) {
+            try {
+                //对jdbc.properties配置的密码密文 进行解密
+                String password = RSAKeysUtil.decryptByPrivateKey(PRIVATE_KEY_STRING, pwd);
+                log.info("decryptByPrivateKey pw: " + password);
+                setPassword(password.toCharArray());
+            } catch (Exception e) {
+                setPassword(pwd.toCharArray());
+            }
+        }
+    }
+}

--- a/saturn-console/src/main/java/com/vip/saturn/job/console/springboot/utils/RSAKeysUtil.java
+++ b/saturn-console/src/main/java/com/vip/saturn/job/console/springboot/utils/RSAKeysUtil.java
@@ -1,0 +1,183 @@
+package com.vip.saturn.job.console.springboot.utils;
+
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Cipher;
+import java.security.*;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+/**
+ * RSA算法
+ *
+*/
+public class RSAKeysUtil {
+    public static final String KEY_ALGORITHM = "RSA";
+
+    public static void main(String[] args) throws Exception {
+        String src = "zSYMAElUu7";
+        System.out.println("\n");
+        RSAKeyPair keyPair = generateKeyPair();
+        System.out.println("公钥：" + keyPair.getPublicKey());
+        System.out.println("私钥：" + keyPair.getPrivateKey());
+        System.out.println("\n");
+        test1(keyPair, src);
+        System.out.println("\n");
+        test2(keyPair, src);
+        System.out.println("\n");
+    }
+
+    /**
+     * 公钥加密私钥解密
+     */
+    private static void test1(RSAKeyPair keyPair, String source) throws Exception {
+        System.out.println("***************** 公钥加密私钥解密开始 *****************");
+        String text1 = encryptByPublicKey(keyPair.getPublicKey(), source);
+        String text2 = decryptByPrivateKey(keyPair.getPrivateKey(), text1);
+        System.out.println("加密前：" + source);
+        System.out.println("加密后：" + text1);
+        System.out.println("解密后：" + text2);
+        if (source.equals(text2)) {
+            System.out.println("解密字符串和原始字符串一致，解密成功");
+        } else {
+            System.out.println("解密字符串和原始字符串不一致，解密失败");
+        }
+        System.out.println("***************** 公钥加密私钥解密结束 *****************");
+    }
+
+    /**
+     * 私钥加密公钥解密
+     *
+     * @throws Exception
+     */
+    private static void test2(RSAKeyPair keyPair, String source) throws Exception {
+        System.out.println("***************** 私钥加密公钥解密开始 *****************");
+        String text1 = encryptByPrivateKey(keyPair.getPrivateKey(), source);
+        String text2 = decryptByPublicKey(keyPair.getPublicKey(), text1);
+        System.out.println("加密前：" + source);
+        System.out.println("加密后：" + text1);
+        System.out.println("解密后：" + text2);
+        if (source.equals(text2)) {
+            System.out.println("解密字符串和原始字符串一致，解密成功");
+        } else {
+            System.out.println("解密字符串和原始字符串不一致，解密失败");
+        }
+        System.out.println("***************** 私钥加密公钥解密结束 *****************");
+    }
+
+    /**
+     * 公钥解密
+     *
+     * @param publicKeyText
+     * @param text
+     * @return
+     * @throws Exception
+     */
+    public static String decryptByPublicKey(String publicKeyText, String text) throws Exception {
+        X509EncodedKeySpec x509EncodedKeySpec = new X509EncodedKeySpec(Base64.decodeBase64(publicKeyText));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PublicKey publicKey = keyFactory.generatePublic(x509EncodedKeySpec);
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.DECRYPT_MODE, publicKey);
+        byte[] result = cipher.doFinal(Base64.decodeBase64(text));
+        return new String(result);
+    }
+
+    /**
+     * 私钥加密
+     *
+     * @param privateKeyText
+     * @param text
+     * @return
+     * @throws Exception
+     */
+    public static String encryptByPrivateKey(String privateKeyText, String text) throws Exception {
+        PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(Base64.decodeBase64(privateKeyText));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PrivateKey privateKey = keyFactory.generatePrivate(pkcs8EncodedKeySpec);
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.ENCRYPT_MODE, privateKey);
+        byte[] result = cipher.doFinal(text.getBytes());
+        return Base64.encodeBase64String(result);
+    }
+
+    /**
+     * 私钥解密
+     *
+     * @param privateKeyText
+     * @param text
+     * @return
+     * @throws Exception
+     */
+    public static String decryptByPrivateKey(String privateKeyText, String text) throws Exception {
+        PKCS8EncodedKeySpec pkcs8EncodedKeySpec5 = new PKCS8EncodedKeySpec(Base64.decodeBase64(privateKeyText));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PrivateKey privateKey = keyFactory.generatePrivate(pkcs8EncodedKeySpec5);
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.DECRYPT_MODE, privateKey);
+        byte[] result = cipher.doFinal(Base64.decodeBase64(text));
+        return new String(result);
+    }
+
+    /**
+     * 公钥加密
+     *
+     * @param publicKeyText
+     * @param text
+     * @return
+     */
+    public static String encryptByPublicKey(String publicKeyText, String text) throws Exception {
+        X509EncodedKeySpec x509EncodedKeySpec2 = new X509EncodedKeySpec(Base64.decodeBase64(publicKeyText));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PublicKey publicKey = keyFactory.generatePublic(x509EncodedKeySpec2);
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+        byte[] result = cipher.doFinal(text.getBytes());
+        return Base64.encodeBase64String(result);
+    }
+
+    /**
+     * 构建RSA密钥对
+     *
+     * @return
+     * @throws NoSuchAlgorithmException
+     */
+    public static RSAKeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM);
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        RSAPublicKey rsaPublicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) keyPair.getPrivate();
+        String publicKeyString = Base64.encodeBase64String(rsaPublicKey.getEncoded());
+        String privateKeyString = Base64.encodeBase64String(rsaPrivateKey.getEncoded());
+        RSAKeyPair rsaKeyPair = new RSAKeyPair(publicKeyString, privateKeyString);
+        return rsaKeyPair;
+    }
+
+    /**
+     * RSA密钥对对象
+     */
+    public static class RSAKeyPair {
+
+        private String publicKey;
+        private String privateKey;
+
+        public RSAKeyPair(String publicKey, String privateKey) {
+            this.publicKey = publicKey;
+            this.privateKey = privateKey;
+        }
+
+        public String getPublicKey() {
+            return publicKey;
+        }
+
+        public String getPrivateKey() {
+            return privateKey;
+        }
+
+    }
+
+
+}

--- a/saturn-console/src/main/java/com/vip/saturn/job/console/springboot/utils/RsaConfigTools.java
+++ b/saturn-console/src/main/java/com/vip/saturn/job/console/springboot/utils/RsaConfigTools.java
@@ -1,0 +1,21 @@
+package com.vip.saturn.job.console.springboot.utils;
+
+public class RsaConfigTools {
+    /**
+     * 私钥对数据进行解密
+     */
+    private static final String PRIVATE_KEY_STRING = "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCCrE/StGyQ/+YVtMA4G3YK2xsFuST4msH18nCgH+OzNkmbmR+9MQ5Pfx2dJXtSEwdcyNPp5UTGejQU+3bIUensX3OsRwm7lnhrWp16VGBgsPyUJd2GVcT7Glte25FMh0SZvQgtO2f5YMSl1GLNYS1pSAonQnOaMB8TxYnV60MMJ7Lf9KDN9dXL0yJpXu+8/v/UoAD+A4qLUKNRA2bwc/SIwUVzLQ1ezoDvy/2GbUZoL9bbt8Zt3elMFPK5XjyPZoRpR4O1I2+40YXzkGX7UWkvilKMLWiH9gc8bb1Lo67qzVbsrK+xX53Fp5uFXWapzVd88uQE1j67OTmmIyNM4jvXAgMBAAECggEBAIBmasUjLq7IFMDtbBd1vGbsZ0AXbiGuh7pxcIOW8jottORk8RAJPQOWZ3X715KNSiW83KYu94aDm9umQFCUVORD4ri80O5363mpf6YtdMpt/rJgBq2yZ61Jd9DctYhaPmlGmts/TWp40KIV8MPYojOaaweqv0cZ09+sskT2OFqezmwITynTFr+oUI8zfwvuXi+dXkosiaH2Po1trP6q3/sO3RVIn1WuFvzIueIRSg4/xm1OU6UQ3tI7aX5sM7GfKTBia0pjQgaDExrp8FbY2RGzfGcZ0J91B66IyLRTPIXnoGYVCkqU8QKeQy2RWZsuUhC5JtIEKYVGHrRe0anQt+kCgYEA8P9G90KQZFrWoERFLtMLYSYimrNdm7Ght0R75q4dobruEH8yl3/IoVnvqe+qRwC/Gtc8Iz1MPvmweP276GyaXds+19E8J+e4VukW239A9CbsRRuVIG6WdAZsOanaE8gMpFX/kgRsgUzkbbKE6XWji3D4YcUjApH9cL/LEio0+rsCgYEAis7SfC5uknxCms1KAVk1NWICkeQWzDQIBfcqN8yaohScTYgwLDsUBd9VgxpeX5TQybRMHtNB/O7YVXyH308vyxN6yvdcTQ2gYviIrI/lggbgwh/qGWZTTHOeLGeVtWJlt33H6YZL5u37cVt86ZXYewFdEDIVrJoSLtNYAdX4l5UCgYB3DEOMJS+aw1y+crsSNGKsrN/vN6eIH6lZFNV30I8Gs4aiU5M0T4VWX00Kzz94L6A3rBci+UbO3R0Vx5GpcOyYbJOQnOVweQEQvbfy2dvGP+v6/3MdQEPGMN4JZiQ6HVpRW8IR6WmIPemhXsxVXy1Y1od8FJwEywU9SyEPahYdvQKBgFtNDM/Xrq01hI3UCCB47/GsBOq3L3Ojqb9awu8u6ms/yUuKD72YImR2cQWp+3c9KFPz/rmr1VSsOamJHsn4iQQ3TOZh69lW5C8VMLjocVqkcYPegBmy34mC5wBoJeXH0gXueucUiapc0K3QMopmIJ1P2UnE19LPCLS6GMIkXr49AoGBAJ7JhexixTTnOyqvZokIaMAC4Ce74jUynJTim0u8yeNchqECeCsfmmrryrkdUFigNt9o00YGF66B6ow20aIBSXxan6/VpZ72ham9l0r9I7xn/OfJNDROr6UFr1N/l1LzlBKI4cdYXa9v9BWj+0gxiLJ3rQ9qbyARXFEzo/Ick2qF";
+
+    /**
+     * 公钥对数据进行加密
+     */
+    public static final String PUBLIC_KEY_STRING = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgqxP0rRskP/mFbTAOBt2CtsbBbkk+JrB9fJwoB/jszZJm5kfvTEOT38dnSV7UhMHXMjT6eVExno0FPt2yFHp7F9zrEcJu5Z4a1qdelRgYLD8lCXdhlXE+xpbXtuRTIdEmb0ILTtn+WDEpdRizWEtaUgKJ0JzmjAfE8WJ1etDDCey3/SgzfXVy9MiaV7vvP7/1KAA/gOKi1CjUQNm8HP0iMFFcy0NXs6A78v9hm1GaC/W27fGbd3pTBTyuV48j2aEaUeDtSNvuNGF85Bl+1FpL4pSjC1oh/YHPG29S6Ou6s1W7KyvsV+dxaebhV1mqc1XfPLkBNY+uzk5piMjTOI71wIDAQAB";
+
+    public static void main(String[] args) throws Exception {
+        //密码明文，也就是数据库的密码
+        String plainText = "zSYMAElUu7";
+        String pd = RSAKeysUtil.encryptByPublicKey(PUBLIC_KEY_STRING,plainText);
+        System.out.println(pd);
+        System.out.println(RSAKeysUtil.decryptByPrivateKey(PRIVATE_KEY_STRING, pd));
+    }
+}

--- a/saturn-console/src/main/resources/context/applicationContext_datasource_h2.xml
+++ b/saturn-console/src/main/resources/context/applicationContext_datasource_h2.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans 
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	   xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
+	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
                         http://www.springframework.org/schema/beans/spring-beans.xsd 
                         http://www.springframework.org/schema/context 
                         http://www.springframework.org/schema/context/spring-context.xsd

--- a/saturn-console/src/main/resources/context/applicationContext_datasource_mysql.xml
+++ b/saturn-console/src/main/resources/context/applicationContext_datasource_mysql.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xmlns:tx="http://www.springframework.org/schema/tx"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
                         http://www.springframework.org/schema/beans/spring-beans.xsd 
                         http://www.springframework.org/schema/context 
                         http://www.springframework.org/schema/context/spring-context.xsd
                         http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
                         ">
+
+    <!--数据源加密操作-->
+    <bean id="dbPasswordCallback" class="com.vip.saturn.job.console.springboot.DbPasswordCallback" lazy-init="true"/>
+
     <bean name="dataSource" class="com.alibaba.druid.pool.DruidDataSource" init-method="init" destroy-method="close" lazy-init="true">
         <property name="url" value="${SATURN_CONSOLE_DB_URL:jdbc:mysql://a.b.c.d}" />
         <property name="username" value="${SATURN_CONSOLE_DB_USERNAME:}" />
@@ -17,12 +21,15 @@
         <property name="minIdle" value="1" />
         <property name="maxActive" value="20" />
         <property name="maxWait" value="60000" />
+        <!--密码加密，${SATURN_CONSOLE_DB_PASSWORD:} 是加密后的数据库用户密码-->
+        <property name="connectionProperties" value="password=${SATURN_CONSOLE_DB_PASSWORD:}"/>
+        <property name="passwordCallback" ref="dbPasswordCallback"/>
         <property name="timeBetweenEvictionRunsMillis" value="60000" />
         <property name="minEvictableIdleTimeMillis" value="300000" />
         <property name="validationQuery" value="SELECT 'x'" />
         <property name="testOnBorrow" value="false" />
         <property name="testOnReturn" value="false" />
         <property name="testWhileIdle" value="true" />
-    </bean>	
-	
+    </bean>
+
 </beans>

--- a/saturn-core/src/main/java/com/vip/saturn/job/internal/failover/FailoverListenerManager.java
+++ b/saturn-core/src/main/java/com/vip/saturn/job/internal/failover/FailoverListenerManager.java
@@ -85,16 +85,15 @@ public class FailoverListenerManager extends AbstractListenerManager {
 		if (jobScheduler == null || jobScheduler.getJob() == null) {
 			return;
 		}
+		LogUtils.info(log, jobName, "zy init failover item : " + item);
 		if (!jobScheduler.getJob().isFailoverSupported() || !configService.isFailover() || executionService
 				.isCompleted(item)) {
+			LogUtils.info(log, jobName, "zy stop failover item : " + item);
 			return;
 		}
-
 		failoverService.createCrashedFailoverFlag(item);
-
-		if (!executionService.hasRunningItems(jobScheduler.getShardingService().getLocalHostShardingItems())) {
-			failoverService.failoverIfNecessary();
-		}
+		LogUtils.info(log, jobName, "zy failover createCrashedFailoverFlag");
+		failoverService.failoverAndExecute();
 	}
 
 	class ExecutionPathListener extends AbstractJobListener {
@@ -155,7 +154,9 @@ public class FailoverListenerManager extends AbstractListenerManager {
 						if (isShutdown) {
 							return;
 						}
+						LogUtils.info(log, jobName, "zy RunningPathListener {} crashed item:{}.",executionService.isRunning(item), item);
 						if (!executionService.isRunning(item)) {
+							LogUtils.info(log, jobName, "zy RunningPathListener-isRunning {} crashed item:{}.",executionService.isRunning(item), item);
 							failover(item);
 						}
 					} catch (Throwable t) {
@@ -183,7 +184,9 @@ public class FailoverListenerManager extends AbstractListenerManager {
 						if (isShutdown) {
 							return;
 						}
+						LogUtils.info(log, jobName, "zy FailoverPathJobListener {} crashed item:{}.",executionService.isFailover(item), item);
 						if (!executionService.isFailover(item)) {
+							LogUtils.info(log, jobName, "zy FailoverPathJobListener-isFailover {} crashed item:{}.",executionService.isFailover(item), item);
 							failover(item);
 						}
 					} catch (Throwable t) {

--- a/saturn-core/src/main/java/com/vip/saturn/job/java/JavaShardingItemCallable.java
+++ b/saturn-core/src/main/java/com/vip/saturn/job/java/JavaShardingItemCallable.java
@@ -175,10 +175,12 @@ public class JavaShardingItemCallable extends ShardingItemCallable {
 
 			// 在此之后，不能再强制停止本线程
 			breakForceStop = true;
+			LogUtils.info(log, jobName, "zy call over");
 		} catch (Throwable t) {
 			// 在此之后，不能再强制停止本线程
 			breakForceStop = true;
 
+			LogUtils.info(log, jobName, "zy call Throwable over");
 			// 不是超时，不是强制停止。 打印错误日志，设置SaturnJobReturn。
 			if (status.get() != TIMEOUT && status.get() != FORCE_STOP) {
 				LogUtils.error(log, jobName, t.toString(), t);

--- a/saturn-core/src/main/java/com/vip/saturn/job/java/ShardingItemFutureTask.java
+++ b/saturn-core/src/main/java/com/vip/saturn/job/java/ShardingItemFutureTask.java
@@ -104,6 +104,7 @@ public class ShardingItemFutureTask implements Callable<SaturnJobReturn> {
 			return;
 		}
 		done = true;
+		LogUtils.info(log, callable.getJobName(), "zy done true");
 		try {
 			try {
 				if (callable.isTimeout()) {

--- a/saturn-core/src/main/java/com/vip/saturn/job/trigger/SaturnWorker.java
+++ b/saturn-core/src/main/java/com/vip/saturn/job/trigger/SaturnWorker.java
@@ -95,6 +95,7 @@ public class SaturnWorker implements Runnable {
 
 	@Override
 	public void run() {
+		LogUtils.info(log, job.getJobName(),"zy saturn work" );
 		while (!halted.get()) {
 			try {
 				synchronized (sigLock) {


### PR DESCRIPTION
为了业务需求，我们使用了saturn作为解析日志的框架，提高解析日志的并发量，当前在生产集群能力已经达到700WTPS，以下是过程中解决的一些问题，请大佬指点下，感谢！
1. saturn console访问数据库进行加密和解密，防止密码暴露；
2. 解决saturn executor分片失败无法立即转移问题；
3. 解决分片失败并立即转移后，saturn console后台分片项没有立即修改问题。