### PR TITLE
Could com.vip.saturn:saturn-plugin:master-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/saturn-plugin/pom.xml
+++ b/saturn-plugin/pom.xml
@@ -71,6 +71,12 @@
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-tools-annotations</artifactId>
 			<version>${maven-plugin-plugin.version}</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>org.codehaus.plexus</groupId>
+				    <artifactId>plexus-component-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		
 		<dependency>
@@ -83,6 +89,56 @@
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-plugin-plugin</artifactId>
 			<version>${maven-plugin-plugin.version}</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>org.apache.maven.plugin-tools</groupId>
+				    <artifactId>maven-plugin-tools-java</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.maven.doxia</groupId>
+				    <artifactId>doxia-module-xhtml</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>net.sf.jtidy</groupId>
+				    <artifactId>jtidy</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>sslext</groupId>
+				    <artifactId>sslext</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>xml-apis</groupId>
+				    <artifactId>xml-apis</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>javax.servlet</groupId>
+				    <artifactId>servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.codehaus.plexus</groupId>
+				    <artifactId>plexus-component-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.maven.doxia</groupId>
+				    <artifactId>doxia-sink-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.maven.doxia</groupId>
+				    <artifactId>doxia-site-renderer</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.maven.doxia</groupId>
+				    <artifactId>doxia-sink-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.maven.doxia</groupId>
+				    <artifactId>doxia-site-renderer</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.maven.plugin-tools</groupId>
+				    <artifactId>maven-plugin-tools-generators</artifactId>
+				</exclusion>
+		         </exclusions>
 		</dependency>
 
 		<dependency>
@@ -123,4 +179,58 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+		    <dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-shared-utils</artifactId>
+			<version>0.6</version>
+		    </dependency>
+		    <dependency>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
+			<version>1.3.1</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.apache.maven.doxia</groupId>
+			<artifactId>doxia-logging-api</artifactId>
+			<version>1.4</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
+			<version>5.0.2</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.apache.maven.doxia</groupId>
+			<artifactId>doxia-core</artifactId>
+			<version>1.4</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.apache.maven.doxia</groupId>
+			<artifactId>doxia-decoration-model</artifactId>
+			<version>1.4</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.apache.maven.doxia</groupId>
+			<artifactId>doxia-module-fml</artifactId>
+			<version>1.4</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-i18n</artifactId>
+			<version>1.0-beta-7</version>
+		    </dependency>
+		    <dependency>
+			<groupId>org.apache.velocity</groupId>
+			<artifactId>velocity-tools</artifactId>
+			<version>2.0</version>
+		    </dependency>
+		    <dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.1</version>
+		    </dependency>
+	       </dependencies>
+      </dependencyManagement>
 </project>


### PR DESCRIPTION
Hi, I am a user of project **_com.vip.saturn:saturn-plugin:master-SNAPSHOT_**. I found that its pom file introduced **_72_** dependencies. However, among them, **_24_** libraries (**_33%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_com.vip.saturn:saturn-plugin:master-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards